### PR TITLE
Updated composer plugin: composer-extra-dependency to version 0.2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "require": {
         "php": "^5.6 || ^7.0",
         "http-interop/http-middleware": "^0.1.1 || ^0.2 || ^0.3 || ^0.4.1 || ^0.5",
-        "webimpress/composer-extra-dependency": "^0.1"
+        "webimpress/composer-extra-dependency": "^0.2"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7.22 || ^6.3.1"


### PR DESCRIPTION
This version does not prompt user to provide the version of required
package, if the package is already installed. Entry to composer.json
is added and message with information how to update package is shown.