### PR TITLE
Added http-interop/http-server-middleware support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,15 +5,15 @@ language: php
 cache:
   directories:
     - $HOME/.composer/cache
-    - vendor
 
 env:
-  - HTTP_MIDDLEWARE_VERSION="^0.1.1"
-  - HTTP_MIDDLEWARE_VERSION="^0.2"
-  - HTTP_MIDDLEWARE_VERSION="^0.3"
-  - HTTP_MIDDLEWARE_VERSION="^0.4.1"
-  - HTTP_MIDDLEWARE_VERSION="^0.5"
-  - HTTP_MIDDLEWARE_VERSION="dev-master"
+  - HTTP_MIDDLEWARE_VERSION="http-interop/http-middleware:^0.1.1"
+  - HTTP_MIDDLEWARE_VERSION="http-interop/http-middleware:^0.2"
+  - HTTP_MIDDLEWARE_VERSION="http-interop/http-middleware:^0.3"
+  - HTTP_MIDDLEWARE_VERSION="http-interop/http-middleware:^0.4.1"
+  - HTTP_MIDDLEWARE_VERSION="http-interop/http-middleware:^0.5"
+  - HTTP_MIDDLEWARE_VERSION="http-interop/http-server-middleware:^1.0.1"
+  - HTTP_MIDDLEWARE_VERSION="http-interop/http-server-middleware:dev-master"
 
 php:
   - 5.6
@@ -21,12 +21,19 @@ php:
   - 7.1
   - 7.2
 
+matrix:
+  exclude:
+    - php: 5.6
+      env: HTTP_MIDDLEWARE_VERSION="http-interop/http-server-middleware:^1.0.1"
+    - php: 5.6
+      env: HTTP_MIDDLEWARE_VERSION="http-interop/http-server-middleware:dev-master"
+
 before_install:
   - phpenv config-rm xdebug.ini || return 0
   - travis_retry composer self-update
 
 install:
-  - travis_retry composer require --no-interaction http-interop/http-middleware:$HTTP_MIDDLEWARE_VERSION
+  - travis_retry composer require --no-interaction $HTTP_MIDDLEWARE_VERSION
   - travis_retry composer install --no-interaction
   - if [[ $TRAVIS_PHP_VERSION =~ ^5.6 ]]; then travis_retry composer update --no-interaction --with-dependencies phpunit/phpunit ; fi
   - stty cols 120 && composer show

--- a/autoload/http-middleware.php
+++ b/autoload/http-middleware.php
@@ -21,6 +21,7 @@ if (interface_exists(\Interop\Http\Middleware\ServerMiddlewareInterface::class)
     } else {
         define(__NAMESPACE__ . '\HANDLER_METHOD', 'process');
     }
+    define(__NAMESPACE__ . '\HAS_RETURN_TYPE', false);
 }
 
 // http-interop/http-middleware 0.4.1
@@ -38,9 +39,10 @@ if (interface_exists(\Interop\Http\ServerMiddleware\MiddlewareInterface::class)
     );
 
     define(__NAMESPACE__ . '\HANDLER_METHOD', 'process');
+    define(__NAMESPACE__ . '\HAS_RETURN_TYPE', false);
 }
 
-// http-interop/http-middleware 0.5.0
+// http-interop/http-middleware 0.5.0 && http-interop/http-server-middleware 1.0.1
 if (interface_exists(\Interop\Http\Server\MiddlewareInterface::class)
     && interface_exists(\Interop\Http\Server\RequestHandlerInterface::class)
 ) {
@@ -55,4 +57,11 @@ if (interface_exists(\Interop\Http\Server\MiddlewareInterface::class)
     );
 
     define(__NAMESPACE__ . '\HANDLER_METHOD', 'handle');
+
+    if (PHP_VERSION_ID >= 70000) {
+        $r = new \ReflectionMethod(MiddlewareInterface::class, 'process');
+        define(__NAMESPACE__ . '\HAS_RETURN_TYPE', $r->hasReturnType());
+    } else {
+        define(__NAMESPACE__ . '\HAS_RETURN_TYPE', false);
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -17,17 +17,19 @@
         "sort-packages": true
     },
     "extra": {
-        "dependency": [
-            "http-interop/http-middleware"
-        ]
+        "dependency-or": {
+            "What middleware package would you like to use?": [
+                "http-interop/http-middleware",
+                "http-interop/http-server-middleware"
+            ]
+        }
     },
     "require": {
         "php": "^5.6 || ^7.0",
-        "http-interop/http-middleware": "^0.1.1 || ^0.2 || ^0.3 || ^0.4.1 || ^0.5",
-        "webimpress/composer-extra-dependency": "^0.2.2"
+        "webimpress/composer-extra-dependency": "dev-feature/dependency-or as 0.3"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7.23 || ^6.4.3"
+        "phpunit/phpunit": "^5.7.23 || ^6.4.4"
     },
     "autoload": {
         "files": [

--- a/test/HandlerInterfaceTest.php
+++ b/test/HandlerInterfaceTest.php
@@ -5,9 +5,10 @@ namespace WebimpressTest\HttpMiddlewareCompatibility;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Psr\Http\Message\ServerRequestInterface;
+use ReflectionMethod;
 use Webimpress\HttpMiddlewareCompatibility\HandlerInterface;
-
 use const Webimpress\HttpMiddlewareCompatibility\HANDLER_METHOD;
+use const Webimpress\HttpMiddlewareCompatibility\HAS_RETURN_TYPE;
 
 class HandlerInterfaceTest extends TestCase
 {
@@ -18,28 +19,40 @@ class HandlerInterfaceTest extends TestCase
 
     public function testHandlerInterfaceIsAliasToBaseLibrary()
     {
-        // 0.3.0, 0.2.0, 0.1.1
+        // http-middleware 0.3.0, 0.2.0, 0.1.1
         if (interface_exists(\Interop\Http\Middleware\DelegateInterface::class)) {
             self::assertTrue(is_a(HandlerInterface::class, \Interop\Http\Middleware\DelegateInterface::class, true));
             self::assertTrue(is_a(\Interop\Http\Middleware\DelegateInterface::class, HandlerInterface::class, true));
+            self::assertSame(
+                method_exists(HandlerInterface::class, 'next') ? 'next' : 'process',
+                HANDLER_METHOD
+            );
+            self::assertFalse(HAS_RETURN_TYPE);
 
             return;
         }
 
-        // 0.4.1
+        // http-middleware 0.4.1
         if (interface_exists(\Interop\Http\ServerMiddleware\DelegateInterface::class)) {
             self::assertTrue(is_a(HandlerInterface::class, \Interop\Http\ServerMiddleware\DelegateInterface::class, true));
             self::assertTrue(is_a(\Interop\Http\ServerMiddleware\DelegateInterface::class, HandlerInterface::class, true));
             self::assertSame('process', HANDLER_METHOD);
+            self::assertFalse(HAS_RETURN_TYPE);
 
             return;
         }
 
-        // 0.5.0
+        // http-middleware 0.5.0 & http-server-middleware 1.0.1
         if (interface_exists(\Interop\Http\Server\RequestHandlerInterface::class)) {
             self::assertTrue(is_a(HandlerInterface::class, \Interop\Http\Server\RequestHandlerInterface::class, true));
             self::assertTrue(is_a(\Interop\Http\Server\RequestHandlerInterface::class, HandlerInterface::class, true));
             self::assertSame('handle', HANDLER_METHOD);
+            $hasReturnType = false;
+            if (PHP_VERSION_ID >= 70000) {
+                $r = new ReflectionMethod(HandlerInterface::class, 'handle');
+                $hasReturnType = $r->hasReturnType();
+            }
+            self::assertSame($hasReturnType, HAS_RETURN_TYPE);
 
             return;
         }


### PR DESCRIPTION
Added new constant `HAS_RETURN_TYPE` - it is set to boolean true only
when `http-interop/http-server-middleware` is used (PHP 7.0+)